### PR TITLE
docs: fix GraphQL photo author schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ type Photo {
   url: String
   width: Int
   height: Int
-  authorId: String
+  author: Author
 }
 ```
 
@@ -273,7 +273,11 @@ query {
       width
       height
       url
-      authorId
+      author {
+        id
+        name
+        url
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- update the documented GraphQL `Photo` schema to expose `author: Author`
- update the `shop` query example to select the nested author fields

## Root cause

The README still documented the internal `authorId` field, while the public GraphQL schema resolves that value to an `Author` object before returning a photo.

## Validation

- confirmed the previous example returns `Cannot query field "authorId" on type "Photo"` from the public endpoint
- confirmed the updated query returns the nested author object from `https://ramen-api.dev/graphql`
- compared the example with `src/graphql.ts` and the existing GraphQL test query
- `git diff --check`

Fixes #13
